### PR TITLE
HOC for wrapping fields [Discussion: No Merge]

### DIFF
--- a/examples/field-wraps/index.js
+++ b/examples/field-wraps/index.js
@@ -1,29 +1,19 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Form, Field } from 'src'
+import { Form } from 'src'
 
 const Input = props => {
   const { name, type, ...rest} = props
   return <input type={type || 'text'} id={`field-` + name} name={name} {...rest} />
 }
 
-const FieldWrap = props => {
-  const { label, type, name, component: Component } = props
-
+const CustomInput = props => {
+  const { input, formState, fieldState, label, name, type } = props;
   return (
-    <Field name={name}>
-      {(input, fieldState, formState) => (
-        <div className="field-wrap">
-          <label htmlFor={`field-` + name}>{label}</label>
-          <div className="input">
-            <Component {...input} name={name} type={type} />
-          </div>
-          <div className="error">
-            {fieldState.error}
-          </div>
-        </div>
-      )}
-    </Field>
+    <fieldset>
+      <label htmlFor={name}>{label}</label>
+      <Input {... input} type={type} />
+    </fieldset>
   )
 }
 
@@ -43,11 +33,12 @@ class Example extends React.Component {
 
   render() {
     const initialValues = { email: 'example@example.com', password: 'abc123' }
-
+    const Email = connectField("email")(CustomInput);
+    const Password = connectField("password")(CustomInput);
     return (
       <Form validate={this.validate} onSubmit={this.onSubmit} initialValues={initialValues}>
-        <FieldWrap label="Email" name="email" component={Input} />
-        <FieldWrap label="Password" name="password" type="password" component={Input} />
+        <Email label="Email" name="email" />
+        <Password label="Password" name="password" type="password" />
         <button type="submit">Submit</button>
       </Form>
     )

--- a/src/connectField.js
+++ b/src/connectField.js
@@ -1,0 +1,43 @@
+import React, {Component, PropTypes} from 'react';
+
+function connectField(name) {
+  return function(WrappedComponent){
+    return class extends Component {
+      componentWillMount() {
+        this.context.registerField(name)
+      }
+      static contextTypes = {
+        registerField: PropTypes.func,
+        getFormState: PropTypes.func,
+        setFieldState: PropTypes.func,
+      }
+      render() {
+        // Bail if name not provided
+        if (!name) throw new Error('You must provide a name to connectField. Usage connectField(name)(Component)')
+        const formState = this.context.getFormState() || {}
+        const fieldState = formState.fields[name]
+
+        // Don't render if fieldState hasn't been setup
+        if (!fieldState) return null
+
+        const input = {
+          name,
+          value: fieldState.value,
+          onChange: e => this.context.setFieldState(name, { value: e.target.value, dirty: true }),
+          onFocus: e => this.context.setFieldState(name, { visited: true, active: true }),
+          onBlur: e => this.context.setFieldState(name, { active: false })
+        }
+
+        // Is this the right syntax? Its late =P
+        // Anyhow support the style of connectField(name)(<input />)
+        if(React.isValidElement(WrappedComponent)) {
+          const newProps = Object.assign({}, {...this.props}, {input, fieldState, formState})
+          return React.clone(WrappedComponent, newProps, this.props.children)
+        }
+        return <WrappedComponent {...this.props} input={input} fieldState={fieldState} formState={formState} />;
+      }
+    }
+  }
+}
+
+export default connectField;


### PR DESCRIPTION
Proposal for providing an HOC for wrapping fields. Its late so there is almost certainly issues with tis and it shouldn't be merged =P Looking for feedback on whether or not you think this is a solid idea.

It does almost exactly the same thing as the old FieldWrap example except we write the HOC and they only need to worry about dealing with the extra props they are given.  This give us the ability to add functionality to the HOC over time without breaking existing consumers.

I'd like to take this farther, walk the tree and just attach the event handlers directly the the `<input />` tag, but I'm not even sure thats possible... and even if it is I'm not entirely convinced we should do it. 

I think this basic HOC adds flexibility while maintaining the current consumption pattern for those that prefer it. Please, tear this apart and tell me why its awful. Your anger sustains me =)